### PR TITLE
Discard windows where max power, is less than requested minimum.

### DIFF
--- a/lib/retune_fft_impl.cc
+++ b/lib/retune_fft_impl.cc
@@ -405,6 +405,13 @@ namespace gr {
                         --skip_fft_count_;
                         continue;
                     }
+                    // Discard windows where max power, is less than requested minimum.
+                    // Ettus radios periodically output low power after retuning. This
+                    // avoids having to use a static skip_fft_count setting.
+                    input_type in_max = *std::max_element(in, in + nfft_);
+                    if (in_max < fft_min_) {
+                        continue;
+                    }
                     write_items_(in);
                     sum_items_(in);
                     ++sample_count_;

--- a/lib/retune_fft_impl.h
+++ b/lib/retune_fft_impl.h
@@ -227,7 +227,7 @@ namespace gr {
       void process_items_(size_t c, const input_type* &in);
       void output_buckets_(const std::string &name, const std::list<std::pair<double, double>> &buckets, std::stringstream &ss);
       void reopen_(double host_now, uint64_t rx_freq);
-	void write_buckets_(double host_now, uint64_t rx_freq);
+      void write_buckets_(double host_now, uint64_t rx_freq);
       void process_tags_(const input_type *in, size_t in_count, size_t in_first);
       void write_(const char *data, size_t len);
       void open_(const std::string &file);


### PR DESCRIPTION
This addresses the "low power after retuning, every 100MHz" Ettus problem.